### PR TITLE
Feature/Add additional information to frame messages objects

### DIFF
--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -169,6 +169,22 @@ ATTRIBUTE_DEFINITION_GENMSGCYCLETIME = AttributeDefinition(
     minimum=0,
     maximum=2**16-1)
 
+ATTRIBUTE_DEFINITION_GENMSGDELAYTIME = AttributeDefinition(
+    name='GenMsgDelayTime',
+    default_value=0,
+    kind='BO_',
+    type_name='INT',
+    minimum=0,
+    maximum=2**16-1)
+
+ATTRIBUTE_DEFINITION_GENMSGSTARTDELAYTIME = AttributeDefinition(
+    name='GenMsgStartDelayTime',
+    default_value=0,
+    kind='BO_',
+    type_name='INT',
+    minimum=0,
+    maximum=2**16-1)
+
 ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition(
     name='GenSigStartValue',
     default_value=0,
@@ -1577,7 +1593,13 @@ def _load_messages(tokens,
             return None
         
     def get_attribute_value(frame_id_dbc, attribute):
-        """Get the attribute value of a given frame id"""
+        """Get the attribute value of a given frame id. Currently supported attributes:
+           - GenMsgSendType: specifies the whether a message is cyclic or sporadic
+           - Type: It is a further specification w.r.t. to GenMsgSendType that gives more details on whether the message is cyclic, sporadic, mixed, etc.
+           - GenMsgCycleTime: Defines the period of a cyclic message
+           - GenMsgDelayTime: Defines the offset w.r.t. to the cycle time
+           - GenMsgStartDelayTime: Defines the time interval between start-up and the first message
+        """
 
         result = None
         message_attributes = get_attributes(frame_id_dbc)

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1576,6 +1576,32 @@ def _load_messages(tokens,
         except KeyError:
             return None
 
+    def get_type(frame_id_dbc):
+        """Get type for a given message.
+
+        """
+
+        result = None
+        message_attributes = get_attributes(frame_id_dbc)
+
+        if message_attributes is None:
+            return result
+
+        try:
+            result = message_attributes['Type'].value
+
+            # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
+            if definitions['Type'].choices is not None:
+                # Resolve ENUM index to ENUM text
+                result = definitions['Type'].choices[int(result)]
+        except (KeyError, TypeError):
+            try:
+                result = definitions['Type'].default_value
+            except (KeyError, TypeError):
+                result = None
+
+        return result
+
     def get_send_type(frame_id_dbc):
         """Get send type for a given message.
 
@@ -1717,6 +1743,7 @@ def _load_messages(tokens,
                     length=int(message[4], 0),
                     senders=senders,
                     send_type=get_send_type(frame_id_dbc),
+                    type=get_type(frame_id_dbc),
                     cycle_time=get_cycle_time(frame_id_dbc),
                     dbc_specifics=DbcSpecifics(get_attributes(frame_id_dbc),
                                                definitions),

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1642,6 +1642,39 @@ def _load_messages(tokens,
 
         return gen_msg_cycle_time_def.default_value or None
 
+    def get_delay_time(frame_id_dbc):
+        """Get delay time for a given message.
+
+        """
+        message_attributes = get_attributes(frame_id_dbc)
+
+        gen_msg_delay_time_def = definitions.get('GenMsgDelayTime')
+        if gen_msg_delay_time_def is None:
+            return None
+
+        if message_attributes:
+            gen_msg_delay_time_attr = message_attributes.get('GenMsgDelayTime')
+            if gen_msg_delay_time_attr:
+                return gen_msg_delay_time_attr.value or None
+
+        return gen_msg_delay_time_def.default_value or None
+
+    def get_start_delay_time(frame_id_dbc):
+        """Get start delay time for a given message.
+
+        """
+        message_attributes = get_attributes(frame_id_dbc)
+
+        gen_msg_start_delay_time_def = definitions.get('GenMsgStartDelayTime')
+        if gen_msg_start_delay_time_def is None:
+            return None
+
+        if message_attributes:
+            gen_msg_start_delay_time_attr = message_attributes.get('GenMsgStartDelayTime')
+            if gen_msg_start_delay_time_attr:
+                return gen_msg_start_delay_time_attr.value or None
+
+        return gen_msg_start_delay_time_def.default_value or None
 
     def get_frame_format(frame_id_dbc):
         """Get frame format for a given message"""
@@ -1745,6 +1778,8 @@ def _load_messages(tokens,
                     send_type=get_send_type(frame_id_dbc),
                     type=get_type(frame_id_dbc),
                     cycle_time=get_cycle_time(frame_id_dbc),
+                    delay_time=get_delay_time(frame_id_dbc),
+                    start_delay_time=get_start_delay_time(frame_id_dbc),
                     dbc_specifics=DbcSpecifics(get_attributes(frame_id_dbc),
                                                definitions),
                     signals=signals,

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -185,6 +185,8 @@ ATTRIBUTE_DEFINITION_GENMSGSTARTDELAYTIME = AttributeDefinition(
     minimum=0,
     maximum=2**16-1)
 
+# TODO: Insert also the ATTRIBUTE_DEFINITION_TYPE, for which is not yet clear what the default value is.
+
 ATTRIBUTE_DEFINITION_GENSIGSTARTVALUE = AttributeDefinition(
     name='GenSigStartValue',
     default_value=0,

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1593,12 +1593,7 @@ def _load_messages(tokens,
             return None
         
     def get_attribute_value(frame_id_dbc, attribute):
-        """Get the attribute value of a given frame id. Currently supported attributes:
-           - GenMsgSendType: specifies the whether a message is cyclic or sporadic
-           - Type: It is a further specification w.r.t. to GenMsgSendType that gives more details on whether the message is cyclic, sporadic, mixed, etc.
-           - GenMsgCycleTime: Defines the period of a cyclic message
-           - GenMsgDelayTime: Defines the offset w.r.t. to the cycle time
-           - GenMsgStartDelayTime: Defines the time interval between start-up and the first message
+        """Get the value of an attribute for a given frame id, possibly returning a default value if it exsists and the attribute is not available, without any ad-hoc processing.
         """
 
         result = None

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -1575,11 +1575,9 @@ def _load_messages(tokens,
             return comments[frame_id_dbc]['message']
         except KeyError:
             return None
-
-    def get_type(frame_id_dbc):
-        """Get type for a given message.
-
-        """
+        
+    def get_attribute_value(frame_id_dbc, attribute):
+        """Get the attribute value of a given frame id"""
 
         result = None
         message_attributes = get_attributes(frame_id_dbc)
@@ -1588,93 +1586,19 @@ def _load_messages(tokens,
             return result
 
         try:
-            result = message_attributes['Type'].value
+            result = message_attributes[attribute].value
 
             # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
-            if definitions['Type'].choices is not None:
+            if definitions[attribute].choices is not None:
                 # Resolve ENUM index to ENUM text
-                result = definitions['Type'].choices[int(result)]
+                result = definitions[attribute].choices[int(result)]
         except (KeyError, TypeError):
             try:
-                result = definitions['Type'].default_value
+                result = definitions[attribute].default_value
             except (KeyError, TypeError):
                 result = None
 
         return result
-
-    def get_send_type(frame_id_dbc):
-        """Get send type for a given message.
-
-        """
-
-        result = None
-        message_attributes = get_attributes(frame_id_dbc)
-
-        try:
-            result = message_attributes['GenMsgSendType'].value
-
-            # if definitions is enum (otherwise above value is maintained) -> Prevents ValueError
-            if definitions['GenMsgSendType'].choices is not None:
-                # Resolve ENUM index to ENUM text
-                result = definitions['GenMsgSendType'].choices[int(result)]
-        except (KeyError, TypeError):
-            try:
-                result = definitions['GenMsgSendType'].default_value
-            except (KeyError, TypeError):
-                result = None
-
-        return result
-
-    def get_cycle_time(frame_id_dbc):
-        """Get cycle time for a given message.
-
-        """
-        message_attributes = get_attributes(frame_id_dbc)
-
-        gen_msg_cycle_time_def = definitions.get('GenMsgCycleTime')
-        if gen_msg_cycle_time_def is None:
-            return None
-
-        if message_attributes:
-            gen_msg_cycle_time_attr = message_attributes.get('GenMsgCycleTime')
-            if gen_msg_cycle_time_attr:
-                return gen_msg_cycle_time_attr.value or None
-
-        return gen_msg_cycle_time_def.default_value or None
-
-    def get_delay_time(frame_id_dbc):
-        """Get delay time for a given message.
-
-        """
-        message_attributes = get_attributes(frame_id_dbc)
-
-        gen_msg_delay_time_def = definitions.get('GenMsgDelayTime')
-        if gen_msg_delay_time_def is None:
-            return None
-
-        if message_attributes:
-            gen_msg_delay_time_attr = message_attributes.get('GenMsgDelayTime')
-            if gen_msg_delay_time_attr:
-                return gen_msg_delay_time_attr.value or None
-
-        return gen_msg_delay_time_def.default_value or None
-
-    def get_start_delay_time(frame_id_dbc):
-        """Get start delay time for a given message.
-
-        """
-        message_attributes = get_attributes(frame_id_dbc)
-
-        gen_msg_start_delay_time_def = definitions.get('GenMsgStartDelayTime')
-        if gen_msg_start_delay_time_def is None:
-            return None
-
-        if message_attributes:
-            gen_msg_start_delay_time_attr = message_attributes.get('GenMsgStartDelayTime')
-            if gen_msg_start_delay_time_attr:
-                return gen_msg_start_delay_time_attr.value or None
-
-        return gen_msg_start_delay_time_def.default_value or None
 
     def get_frame_format(frame_id_dbc):
         """Get frame format for a given message"""
@@ -1775,11 +1699,11 @@ def _load_messages(tokens,
                     name=get_message_name(frame_id_dbc, message[2]),
                     length=int(message[4], 0),
                     senders=senders,
-                    send_type=get_send_type(frame_id_dbc),
-                    type=get_type(frame_id_dbc),
-                    cycle_time=get_cycle_time(frame_id_dbc),
-                    delay_time=get_delay_time(frame_id_dbc),
-                    start_delay_time=get_start_delay_time(frame_id_dbc),
+                    send_type=get_attribute_value(frame_id_dbc, 'GenMsgSendType'),
+                    type=get_attribute_value(frame_id_dbc, 'Type'),
+                    cycle_time=get_attribute_value(frame_id_dbc, 'GenMsgCycleTime'),
+                    delay_time=get_attribute_value(frame_id_dbc, 'GenMsgDelayTime'),
+                    start_delay_time=get_attribute_value(frame_id_dbc, 'GenMsgStartDelayTime'),
                     dbc_specifics=DbcSpecifics(get_attributes(frame_id_dbc),
                                                definitions),
                     signals=signals,

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -77,6 +77,7 @@ class Message:
                  comment: Optional[Union[str, Comments]] = None,
                  senders: Optional[List[str]] = None,
                  send_type: Optional[str] = None,
+                 type: Optional[str] = None,
                  cycle_time: Optional[int] = None,
                  dbc_specifics: Optional['DbcSpecifics'] = None,
                  autosar_specifics: Optional['AutosarMessageSpecifics'] = None,
@@ -132,6 +133,7 @@ class Message:
 
         self._senders = senders if senders else []
         self._send_type = send_type
+        self._type = type
         self._cycle_time = cycle_time
         self._dbc = dbc_specifics
         self._autosar = autosar_specifics
@@ -444,6 +446,14 @@ class Message:
         """
 
         return self._send_type
+
+    @property
+    def type(self) -> Optional[str]:
+        """The message type, or ``None`` if unavailable.
+
+        """
+
+        return self._type
 
     @property
     def cycle_time(self) -> Optional[int]:
@@ -1325,4 +1335,7 @@ class Message:
             f'0x{self._frame_id:x}, ' \
             f'{self._is_extended_frame}, '\
             f'{self._length}, ' \
-            f'{self._comments})'
+            f'{self._comments}, ' \
+            f'{self.cycle_time}, ' \
+            f'{self.send_type}, ' \
+            f'{self.type})'

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -1335,7 +1335,4 @@ class Message:
             f'0x{self._frame_id:x}, ' \
             f'{self._is_extended_frame}, '\
             f'{self._length}, ' \
-            f'{self._comments}, ' \
-            f'{self.cycle_time}, ' \
-            f'{self.send_type}, ' \
-            f'{self.type})'
+            f'{self._comments})' \

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -453,7 +453,7 @@ class Message:
 
     @property
     def type(self) -> Optional[str]:
-        """The message type, or ``None`` if unavailable.
+        """The message type which indicates whether the message is cyclic, cyclic on change, sporadic, etc. ``None`` if unavailable.
 
         """
 
@@ -461,7 +461,7 @@ class Message:
 
     @property
     def cycle_time(self) -> Optional[int]:
-        """The message cycle time, or ``None`` if unavailable.
+        """The message cycle time in case of a periodic message, or ``None`` if unavailable.
 
         """
 
@@ -469,7 +469,12 @@ class Message:
 
     @property
     def delay_time(self) -> Optional[int]:
-        """The message delay time, or ``None`` if unavailable.
+        """The offset with respect to the message period. E.g.:
+            - period -> 5 ms
+            - delay -> 1 ms
+            - schedule time -> period + delay = 6 ms
+        
+        ``None`` if unavailable.
 
         """
 
@@ -477,7 +482,7 @@ class Message:
 
     @property
     def start_delay_time(self) -> Optional[int]:
-        """The start delay time, or ``None`` if unavailable.
+        """The offset with respect to the start-up and the time that the first message is sent. ``None`` if unavailable.
 
         """
 

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -79,6 +79,8 @@ class Message:
                  send_type: Optional[str] = None,
                  type: Optional[str] = None,
                  cycle_time: Optional[int] = None,
+                 delay_time: Optional[int] = None,
+                 start_delay_time: Optional[int] = None,
                  dbc_specifics: Optional['DbcSpecifics'] = None,
                  autosar_specifics: Optional['AutosarMessageSpecifics'] = None,
                  is_extended_frame: bool = False,
@@ -135,6 +137,8 @@ class Message:
         self._send_type = send_type
         self._type = type
         self._cycle_time = cycle_time
+        self._delay_time = delay_time
+        self._start_delay_time = start_delay_time
         self._dbc = dbc_specifics
         self._autosar = autosar_specifics
         self._bus_name = bus_name
@@ -462,6 +466,22 @@ class Message:
         """
 
         return self._cycle_time
+
+    @property
+    def delay_time(self) -> Optional[int]:
+        """The message delay time, or ``None`` if unavailable.
+
+        """
+
+        return self._delay_time
+
+    @property
+    def start_delay_time(self) -> Optional[int]:
+        """The start delay time, or ``None`` if unavailable.
+
+        """
+
+        return self._start_delay_time
 
     @cycle_time.setter
     def cycle_time(self, value: Optional[int]) -> None:
@@ -1335,4 +1355,4 @@ class Message:
             f'0x{self._frame_id:x}, ' \
             f'{self._is_extended_frame}, '\
             f'{self._length}, ' \
-            f'{self._comments})' \
+            f'{self._comments})'


### PR DESCRIPTION
This PR allows to collect more detailed information on the frame message object. In particular:

- Type --> whether the message is periodic, sporadic or mixed
- Delay --> if and how much delay can be applied to the message
- Start Delay --> time from startup to delay before sending the first message frame