### PR TITLE
Feature/Fixes to cantools to allow parsing ARXML files

### DIFF
--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -90,6 +90,7 @@ def _load_file_cache(filename: StringPathLike,
                                 frame_id_mask,
                                 prune_choices,
                                 strict,
+                                False,
                                 sort_signals)
             cache[key] = database
 
@@ -313,6 +314,9 @@ def load_string(string: str,
 
     See :class:`can.Database<.can.Database>` for a description of
     `strict`.
+
+    `best_effort` is a bool indicating whether to continue the execution upon errors or situations
+    in which the network definition file is not well formatted
 
     `sort_signals` is a function taking a list of signals as argument and returning a list of signals.
     By default signals are sorted by their start bit when their Message object is created.

--- a/src/cantools/database/__init__.py
+++ b/src/cantools/database/__init__.py
@@ -102,6 +102,7 @@ def load_file(filename: StringPathLike,
               frame_id_mask: Optional[int] = None,
               prune_choices: bool = False,
               strict: bool = True,
+              best_effort: bool = False,
               cache_dir: Optional[str] = None,
               sort_signals: utils.type_sort_signals = utils.sort_signals_by_start_bit,
               ) -> Union[can.Database, diagnostics.Database]:
@@ -190,6 +191,7 @@ def load_file(filename: StringPathLike,
                         frame_id_mask,
                         prune_choices,
                         strict,
+                        best_effort,
                         sort_signals)
     else:
         return _load_file_cache(filename,
@@ -258,6 +260,7 @@ def load(fp: TextIO,
          frame_id_mask: Optional[int] = None,
          prune_choices: bool = False,
          strict: bool = True,
+         best_effort: bool = False,
          sort_signals: utils.type_sort_signals = utils.sort_signals_by_start_bit) -> Union[can.Database, diagnostics.Database]:
     """Read and parse given database file-like object and return a
     :class:`can.Database<.can.Database>` or
@@ -284,6 +287,7 @@ def load(fp: TextIO,
                        frame_id_mask,
                        prune_choices,
                        strict,
+                       best_effort,
                        sort_signals)
 
 
@@ -292,6 +296,7 @@ def load_string(string: str,
                 frame_id_mask: Optional[int] = None,
                 prune_choices: bool = False,
                 strict: bool = True,
+                best_effort: bool = False,
                 sort_signals: utils.type_sort_signals = utils.sort_signals_by_start_bit) \
         -> Union[can.Database, diagnostics.Database]:
     """Parse given database string and return a
@@ -341,6 +346,7 @@ def load_string(string: str,
     def load_can_database(fmt: str) -> can.Database:
         db = can.Database(frame_id_mask=frame_id_mask,
                           strict=strict,
+                          best_effort=best_effort,
                           sort_signals=sort_signals)
 
         if fmt == 'arxml':

--- a/src/cantools/database/can/database.py
+++ b/src/cantools/database/can/database.py
@@ -260,7 +260,7 @@ class Database:
 
         """
 
-        database = arxml.load_string(string, self._strict, sort_signals=self._sort_signals)
+        database = arxml.load_string(string, self._strict, self._best_effort, sort_signals=self._sort_signals)
 
         self._messages += database.messages
         self._nodes = database.nodes

--- a/src/cantools/database/can/database.py
+++ b/src/cantools/database/can/database.py
@@ -56,6 +56,7 @@ class Database:
                  autosar_specifics: Optional[AutosarDatabaseSpecifics] = None,
                  frame_id_mask: Optional[int] = None,
                  strict: bool = True,
+                 best_effort: bool = False,
                  sort_signals: type_sort_signals = sort_signals_by_start_bit,
                  ) -> None:
         self._messages = messages or []
@@ -72,6 +73,7 @@ class Database:
 
         self._frame_id_mask = frame_id_mask
         self._strict = strict
+        self._best_effort = best_effort
         self._sort_signals = sort_signals
         self.refresh()
 

--- a/src/cantools/database/can/formats/arxml/__init__.py
+++ b/src/cantools/database/can/formats/arxml/__init__.py
@@ -39,6 +39,7 @@ def is_ecu_extract(root: Any # For whatever reason, mypy does not
 
 def load_string(string:str,
                 strict:bool=True,
+                best_effort:bool=False,
                 sort_signals:type_sort_signals=sort_signals_by_start_bit) \
             -> InternalDatabase:
     """Parse given ARXML format string.
@@ -70,4 +71,4 @@ def load_string(string:str,
 
         return EcuExtractLoader(root, strict, sort_signals).load()
     else:
-        return SystemLoader(root, strict, sort_signals).load()
+        return SystemLoader(root, strict, best_effort, sort_signals).load()

--- a/src/cantools/database/can/formats/arxml/system_loader.py
+++ b/src/cantools/database/can/formats/arxml/system_loader.py
@@ -1025,7 +1025,8 @@ class SystemLoader:
                             unused_bit_pattern=unused_bit_pattern,
                             comment=comments,
                             autosar_specifics=contained_autosar_specifics,
-                            sort_signals=self._sort_signals)
+                            sort_signals=self._sort_signals,
+                            strict=self._strict)
 
                 contained_messages.append(contained_message)
 
@@ -1212,6 +1213,14 @@ class SystemLoader:
             # includes it in every dynamic part)
             dynalt_selector_signals = \
                 [ x for x in dynalt_signals if x.start == selector_pos ]
+            
+            if len(dynalt_selector_signals) == 0:
+                # TODO: check whether this is enforced by the ARXML standard.
+                #       for now, if the dynamic alternative selector signals
+                #       cannot be found, skip this PDU
+                LOGGER.warning(f"Skipping multiplexed dynamic signal {dynalt_pdu}")
+                continue
+
             assert len(dynalt_selector_signals) == 1
             dselsig = dynalt_selector_signals[0]
             assert dselsig.start == selector_pos
@@ -1877,6 +1886,13 @@ class SystemLoader:
             if vt is not None:
                 # the current scale is an enumeration value
                 lower_limit, upper_limit = self._load_scale_limits(compu_scale)
+
+                # TODO: handle cases where lower limit and upper limits are None
+                #       for the time being we skip the compu scale
+                if lower_limit is None or upper_limit is None:
+                    LOGGER.warning(f"Skipping compu scale as it does not have valid upper and lower limits")
+                    continue
+
                 assert(lower_limit is not None \
                        and lower_limit == upper_limit)
                 value = lower_limit

--- a/src/cantools/database/can/formats/arxml/system_loader.py
+++ b/src/cantools/database/can/formats/arxml/system_loader.py
@@ -1891,7 +1891,7 @@ class SystemLoader:
 
                 # TODO: handle cases where lower limit and upper limits are None
                 #       for the time being we skip the compu scale
-                if lower_limit is None or upper_limit is None and self._best_effort:
+                if (lower_limit is None or upper_limit is None) and self._best_effort:
                     LOGGER.warning(f"Skipping compu scale as it does not have valid upper and lower limits")
                     continue
 

--- a/src/cantools/database/can/formats/arxml/system_loader.py
+++ b/src/cantools/database/can/formats/arxml/system_loader.py
@@ -26,10 +26,12 @@ LOGGER = logging.getLogger(__name__)
 class SystemLoader:
     def __init__(self,
                  root:Any,
-                 strict:bool,
+                 strict: bool,
+                 best_effort: bool=False,
                  sort_signals:type_sort_signals=sort_signals_by_start_bit):
         self._root = root
         self._strict = strict
+        self._best_effort = best_effort
         self._sort_signals = sort_signals
 
         m = re.match(r'^\{(.*)\}AUTOSAR$', self._root.tag)
@@ -1214,7 +1216,7 @@ class SystemLoader:
             dynalt_selector_signals = \
                 [ x for x in dynalt_signals if x.start == selector_pos ]
             
-            if len(dynalt_selector_signals) == 0:
+            if len(dynalt_selector_signals) == 0 and self._best_effort:
                 # TODO: check whether this is enforced by the ARXML standard.
                 #       for now, if the dynamic alternative selector signals
                 #       cannot be found, skip this PDU
@@ -1889,7 +1891,7 @@ class SystemLoader:
 
                 # TODO: handle cases where lower limit and upper limits are None
                 #       for the time being we skip the compu scale
-                if lower_limit is None or upper_limit is None:
+                if lower_limit is None or upper_limit is None and self._best_effort:
                     LOGGER.warning(f"Skipping compu scale as it does not have valid upper and lower limits")
                     continue
 

--- a/src/cantools/database/can/formats/arxml/utils.py
+++ b/src/cantools/database/can/formats/arxml/utils.py
@@ -2,7 +2,7 @@
 from typing import Union
 
 
-def parse_number_string(in_string : str, allow_float : bool=False) \
+def parse_number_string(in_string : str, allow_float : bool=True) \
     -> Union[int, float]:
     """Convert a string representing numeric value that is specified
     within an ARXML file to either an integer or a floating point object

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -1305,9 +1305,9 @@ class Message:
         # signals.
         for offset, signal_bit in enumerate(signal_bits):
             if signal_bit is not None:
-                if message_bits[offset] is not None and self._strict:
+                if message_bits[offset] is not None:
                     raise Error(
-                        f'The signals {signal.name} and {message_bits[offset]} are overlapping in message {self.name}. {self._strict}')
+                        f'The signals {signal.name} and {message_bits[offset]} are overlapping in message {self.name}')
 
                 message_bits[offset] = signal.name
 

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -1305,9 +1305,9 @@ class Message:
         # signals.
         for offset, signal_bit in enumerate(signal_bits):
             if signal_bit is not None:
-                if message_bits[offset] is not None:
+                if message_bits[offset] is not None and self._strict:
                     raise Error(
-                        f'The signals {signal.name} and {message_bits[offset]} are overlapping in message {self.name}.')
+                        f'The signals {signal.name} and {message_bits[offset]} are overlapping in message {self.name}. {self._strict}')
 
                 message_bits[offset] = signal.name
 

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -1307,7 +1307,7 @@ class Message:
             if signal_bit is not None:
                 if message_bits[offset] is not None:
                     raise Error(
-                        f'The signals {signal.name} and {message_bits[offset]} are overlapping in message {self.name}')
+                        f'The signals {signal.name} and {message_bits[offset]} are overlapping in message {self.name}.')
 
                 message_bits[offset] = signal.name
 


### PR DESCRIPTION
This PR adds some patches to be further analyzed to allow parsing ARXML files without errors.

Patches applied:

- some compu methods may not have upper or lower limits. Need to verify whether this is actually something possible or is enforced by the autosar standard.
- some selector signals for multiplexed PDUs cannot be found. We need to analyze whether this is something that is possible or if the selector signals can be described differently therefore the cantools parser should be enhanced.
- always parse numbers allowing float representation

For the time being the main encountered errors are skipped