### PR TITLE
Name CAN Bus after it's AUTOSAR PhysicalChannel

### DIFF
--- a/src/cantools/database/can/bus.py
+++ b/src/cantools/database/can/bus.py
@@ -1,12 +1,18 @@
 # A CAN bus.
+from typing import NewType, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cantools.database.can.formats.arxml.bus_specifics import AutosarBusSpecifics
 
 class Bus:
     """A CAN bus.
 
     """
 
+    BusName = NewType('BusName', str)
+
     def __init__(self,
-                 name,
+                 name: str,
                  comment=None,
                  baudrate=None,
                  fd_baudrate=None,
@@ -31,7 +37,7 @@ class Bus:
         self._autosar = autosar_specifics
 
     @property
-    def name(self):
+    def name(self) -> BusName:
         """The bus name as a string.
 
         """
@@ -81,7 +87,7 @@ class Bus:
         return self._fd_baudrate
 
     @property
-    def autosar(self):
+    def autosar(self) -> Optional["AutosarBusSpecifics"]:
         """An object containing AUTOSAR specific properties of the bus.
 
         """

--- a/src/cantools/database/can/formats/arxml/bus_specifics.py
+++ b/src/cantools/database/can/formats/arxml/bus_specifics.py
@@ -1,6 +1,23 @@
+from typing import NewType
+
+
 class AutosarBusSpecifics:
     """This class collects the AUTOSAR specific information of a CAN bus
 
     """
+    AutosarBusSpecificsClusterName = NewType('AutosarBusSpecificsClusterName', str)
     def __init__(self, cluster_name: str):
-        self.cluster_name = cluster_name
+        self._cluster_name = cluster_name
+
+    @property
+    def cluster_name(self) -> AutosarBusSpecificsClusterName:
+        """The name of the AUTOSAR cluster to which the bus belongs.
+
+        """
+        return self._cluster_name
+
+    def __repr__(self) -> str:
+        """Return a string representation of the object.
+
+        """
+        return f"AutosarBusSpecifics(cluster_name={self._cluster_name})"

--- a/src/cantools/database/can/formats/arxml/bus_specifics.py
+++ b/src/cantools/database/can/formats/arxml/bus_specifics.py
@@ -2,5 +2,5 @@ class AutosarBusSpecifics:
     """This class collects the AUTOSAR specific information of a CAN bus
 
     """
-    def __init__(self):
-        pass
+    def __init__(self, cluster_name: str):
+        self.cluster_name = cluster_name

--- a/src/cantools/database/can/formats/dbc.py
+++ b/src/cantools/database/can/formats/dbc.py
@@ -5,6 +5,7 @@ from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from decimal import Decimal
 from typing import List
+import typing
 
 import textparser
 from textparser import (
@@ -1575,7 +1576,7 @@ def _load_messages(tokens,
                    signal_types,
                    signal_multiplexer_values,
                    strict,
-                   bus_name,
+                   bus_name: typing.Optional["Bus.BusName"],
                    signal_groups,
                    sort_signals):
     """Load messages.

--- a/src/cantools/database/can/formats/kcd.py
+++ b/src/cantools/database/can/formats/kcd.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Optional
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 
@@ -168,7 +168,7 @@ def _load_multiplex_element(mux, nodes):
     return signals
 
 
-def _load_message_element(message, bus_name, nodes, strict, sort_signals):
+def _load_message_element(message, bus_name: Optional["Bus.BusName"], nodes, strict, sort_signals):
     """Load given message element and return a message object.
 
     """
@@ -485,11 +485,12 @@ def load_string(string:str, strict:bool=True, sort_signals:type_sort_signals=sor
     for bus in root.iterfind('ns:Bus', NAMESPACES):
         bus_name = bus.attrib['name']
         bus_baudrate = int(bus.get('baudrate', 500000))
-        buses.append(Bus(bus_name, baudrate=bus_baudrate))
+        bus_details = Bus(bus_name, baudrate=bus_baudrate)
+        buses.append(bus_details)
 
         for message in bus.iterfind('ns:Message', NAMESPACES):
             messages.append(_load_message_element(message,
-                                                  bus_name,
+                                                  bus_details.name,
                                                   nodes,
                                                   strict,
                                                   sort_signals))

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -45,6 +45,7 @@ from .signal_group import SignalGroup
 if TYPE_CHECKING:
     from .formats.arxml import AutosarMessageSpecifics
     from .formats.dbc import DbcSpecifics
+    from .bus import Bus
 
 LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +87,7 @@ class Message:
                  autosar_specifics: Optional['AutosarMessageSpecifics'] = None,
                  is_extended_frame: bool = False,
                  is_fd: bool = False,
-                 bus_name: Optional[str] = None,
+                 bus_name: Optional["Bus.BusName"] = None,
                  signal_groups: Optional[List[SignalGroup]] = None,
                  strict: bool = True,
                  protocol: Optional[str] = None,
@@ -529,7 +530,7 @@ class Message:
         self._autosar = value
 
     @property
-    def bus_name(self) -> Optional[str]:
+    def bus_name(self) -> Optional["Bus.BusName"]:
         """The message bus name, or ``None`` if unavailable.
 
         """
@@ -537,7 +538,7 @@ class Message:
         return self._bus_name
 
     @bus_name.setter
-    def bus_name(self, value: Optional[str]) -> None:
+    def bus_name(self, value: Optional["Bus.BusName"]) -> None:
         self._bus_name = value
 
     @property

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4687,7 +4687,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(len(db.buses), 1)
         bus = db.buses[0]
-        self.assertEqual(bus.name, 'Cluster0')
+        self.assertEqual(bus.name, 'Pch0')
         self.assertEqual(bus.comment, 'The great CAN cluster')
         self.assertEqual(bus.comments, { 'FOR-ALL': 'The great CAN cluster' })
         self.assertEqual(bus.baudrate, 500000)
@@ -4696,6 +4696,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(db.nodes), 3)
         self.assertEqual(len(db.messages), 8)
         self.assertTrue(db.autosar is not None)
+        self.assertEqual(bus.autosar.cluster_name, 'Cluster0')
         self.assertTrue(db.dbc is None)
         self.assertEqual(db.autosar.arxml_version, "4.0.0")
 
@@ -4723,7 +4724,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(mux_message.send_type, None)
         self.assertEqual(mux_message.cycle_time, None)
         self.assertEqual(len(mux_message.signals), 6)
-        self.assertEqual(mux_message.bus_name, 'Cluster0')
+        self.assertEqual(mux_message.bus_name, 'Pch0')
         self.assertEqual(mux_message.comments, None)
         self.assertEqual(mux_message.comment, None)
         self.assertTrue(mux_message.dbc is None)
@@ -4834,7 +4835,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(message_1.signals), 5)
         self.assertEqual(message_1.comments["DE"], 'Kommentar1')
         self.assertEqual(message_1.comments["EN"], 'Comment1')
-        self.assertEqual(message_1.bus_name, 'Cluster0')
+        self.assertEqual(message_1.bus_name, 'Pch0')
         self.assertEqual(message_1.comment, 'Comment1')
         message_1.comments = {'DE': 'Kommentar eins', 'EN': 'Comment one'}
         self.assertEqual(message_1.comments,
@@ -4966,7 +4967,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_2.cycle_time, 200)
         self.assertEqual(len(message_2.signals), 3)
         self.assertEqual(message_2.comment, None)
-        self.assertEqual(message_2.bus_name, 'Cluster0')
+        self.assertEqual(message_2.bus_name, 'Pch0')
         self.assertTrue(message_2.dbc is None)
         self.assertTrue(message_2.autosar is not None)
         self.assertEqual(message_2.autosar.pdu_paths, [ '/ISignalIPdu/message2' ])
@@ -5039,7 +5040,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_3.cycle_time, None)
         self.assertEqual(len(message_3.signals), 4)
         self.assertEqual(message_3.comment, None)
-        self.assertEqual(message_3.bus_name, 'Cluster0')
+        self.assertEqual(message_3.bus_name, 'Pch0')
         self.assertTrue(message_3.dbc is None)
         self.assertTrue(message_3.autosar is not None)
         self.assertEqual(message_3.autosar.pdu_paths,
@@ -5133,7 +5134,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_4.cycle_time, None)
         self.assertEqual(len(message_4.signals), 3)
         self.assertEqual(message_4.comment, None)
-        self.assertEqual(message_4.bus_name, 'Cluster0')
+        self.assertEqual(message_4.bus_name, 'Pch0')
         self.assertTrue(message_4.dbc is None)
         self.assertTrue(message_4.autosar is not None)
         self.assertEqual(message_4.autosar.pdu_paths, [ '/ISignalIPdu/message4' ])
@@ -5164,7 +5165,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(container_message.cycle_time, None)
         self.assertEqual(len(container_message.signals), 0)
         self.assertEqual(container_message.comment, None)
-        self.assertEqual(container_message.bus_name, 'Cluster0')
+        self.assertEqual(container_message.bus_name, 'Pch0')
         self.assertEqual(len(container_message._contained_messages), 5)
         header_ids = sorted([cm.header_id for cm in container_message._contained_messages])
         self.assertEqual(header_ids, [ 0x010203, 0x040506, 0x070809, 0x0a0b0c, 0x1d2e3f ])
@@ -5194,7 +5195,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(nm_message.cycle_time, None)
         self.assertEqual(len(nm_message.signals), 1)
         self.assertEqual(nm_message.comment, None)
-        self.assertEqual(nm_message.bus_name, 'Cluster0')
+        self.assertEqual(nm_message.bus_name, 'Pch0')
         self.assertTrue(nm_message.dbc is None)
         self.assertTrue(nm_message.autosar is not None)
 
@@ -5208,7 +5209,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(msg_without_pdu.cycle_time, None)
         self.assertEqual(len(msg_without_pdu.signals), 0)
         self.assertEqual(msg_without_pdu.comment, None)
-        self.assertEqual(msg_without_pdu.bus_name, 'Cluster0')
+        self.assertEqual(msg_without_pdu.bus_name, 'Pch0')
         self.assertTrue(msg_without_pdu.dbc is None)
         self.assertTrue(msg_without_pdu.autosar is not None)
 
@@ -5277,7 +5278,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(len(db.buses), 1)
         bus = db.buses[0]
-        self.assertEqual(bus.name, 'MY_CLUSTER')
+        self.assertEqual(bus.name, 'CHNL')
+        self.assertTrue(bus.autosar is not None)
+        self.assertEqual(bus.autosar.cluster_name, 'MY_CLUSTER')
         self.assertEqual(bus.comment, None)
         self.assertEqual(bus.comments, None)
         self.assertEqual(bus.baudrate, 500000)
@@ -5298,7 +5301,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.send_type, None)
         self.assertEqual(message_1.cycle_time, 200)
         self.assertEqual(message_1.comments, None)
-        self.assertEqual(message_1.bus_name, 'MY_CLUSTER')
+        self.assertEqual(message_1.bus_name, 'CHNL')
         self.assertEqual(len(message_1.signals), 1)
 
         # signal

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -175,7 +175,7 @@ Guard:
             # check make sure it behaves as expected
             expected_output = """\
 Message2:
-  Bus: Cluster0
+  Bus: Pch0
   Sending ECUs: Dancer
   Frame ID: 0x6 (6)
   Size: 7 bytes
@@ -235,7 +235,7 @@ Message2:
             # check make sure it behaves as expected
             expected_output = """\
 AlarmStatus:
-  Bus: Cluster0
+  Bus: Pch0
   Sending ECUs: Guard
   Frame ID: 0x3e9 (1001)
   Size: 1 bytes
@@ -327,7 +327,7 @@ No message named "IAmAGhost" has been found in input file.
 Message1:
   Comment[EN]: Comment1
   Comment[DE]: Kommentar1
-  Bus: Cluster0
+  Bus: Pch0
   Sending ECUs: DJ
   Frame ID: 0x5 (5)
   Size: 9 bytes
@@ -418,7 +418,7 @@ Message1:
             # check make sure it behaves as expected
             expected_output = """\
 Message3:
-  Bus: Cluster0
+  Bus: Pch0
   Sending ECUs: Dancer
   Frame ID: 0x64 (100)
   Size: 6 bytes
@@ -492,7 +492,7 @@ Message3:
 
             # check make sure it behaves as expected
             expected_output = """\
-Cluster0:
+Pch0:
   Comment[FOR-ALL]: The great CAN cluster
   Baudrate: 500000
   CAN-FD enabled: True


### PR DESCRIPTION
This PR switches the naming of CAN Bus entities to their only Physical Channel's name instead of the Communication Cluster's name, which is usually describing the aggregation of the Bus plus its communicating entities (e.g., ECUs).

NOTE: this is possible since the AUTOSAR documetation (both for version 3 and 4) clearly state che CAN Communication Clusters have **exatcly one** Pyhisical Channel.

See

- AUTOSAR 4: AUTOSAR TPS SystemTemplate - Table 3.7: PhysicalChannel
- AUTOSAR 3: AUTOSAR SystemTemplate - Table 2.6: PhysicalChannel