### PR TITLE
Feature/extend parsed information from arxml

### DIFF
--- a/src/cantools/database/can/formats/arxml/bus_specifics.py
+++ b/src/cantools/database/can/formats/arxml/bus_specifics.py
@@ -1,13 +1,31 @@
-from typing import NewType
+from typing import List, NewType
 
+class AutosarCommConnector:
+    def __init__(self, name: str, ref: str, node_ref: str):
+        self._name = name
+        self._ref = ref
+        self._node_ref = node_ref
+    
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def ref(self):
+        return self._ref
+    
+    @property
+    def node_ref(self):
+        return self._node_ref
 
 class AutosarBusSpecifics:
     """This class collects the AUTOSAR specific information of a CAN bus
 
     """
     AutosarBusSpecificsClusterName = NewType('AutosarBusSpecificsClusterName', str)
-    def __init__(self, cluster_name: str):
+    def __init__(self, cluster_name: str, comm_connectors: List[AutosarCommConnector]):
         self._cluster_name = cluster_name
+        self._comm_connectors = comm_connectors
 
     @property
     def cluster_name(self) -> AutosarBusSpecificsClusterName:
@@ -15,6 +33,13 @@ class AutosarBusSpecifics:
 
         """
         return self._cluster_name
+    
+    @property
+    def comm_connectors(self) -> List[AutosarCommConnector]:
+        """The communication connectors attached to this bus.
+
+        """
+        return self._comm_connectors
 
     def __repr__(self) -> str:
         """Return a string representation of the object.

--- a/src/cantools/database/can/formats/arxml/gateway.py
+++ b/src/cantools/database/can/formats/arxml/gateway.py
@@ -1,0 +1,78 @@
+# A CAN Gateway
+from typing import Dict, List, Set, Tuple
+
+class Gateway:
+    """A CAN gateway.
+
+    """
+
+    def __init__(self,
+                 name: str,
+                 node_ref: str,
+                 pdu_triggering_routes: List[Tuple[str, str]]
+                 ) -> None:
+        self._name = name
+        self._node_ref = node_ref
+        self._pdu_triggering_routes = pdu_triggering_routes
+
+    @property
+    def name(self) -> str:
+        """The gateway name as a string.
+
+        """
+
+        return self._name
+
+    @property
+    def node_ref(self) -> str:
+        """The node ref name as a string.
+
+        """
+
+        return self._node_ref
+    
+    @staticmethod
+    def get_pdu_triggering_routes(gateways: List["Gateway"]) -> Dict[str, Tuple[str, List[str]]]:
+        """
+        Given a list of gateways, return a dictionary storing for each 
+        pdu triggering path its source pdu triggering path and the list of gateways
+        traversed in the route
+        """
+        target_to_source: Dict[str, Tuple[str, str]] = {}
+        for gateway in gateways:
+            for source, target in gateway._pdu_triggering_routes:
+                # NOTE: if multiple sources can lead to the same target
+                # we take the lexicographically smaller source pair
+                source_pair = (source, gateway.name)
+                if target_to_source.get(target, source_pair) <= source_pair:
+                    target_to_source[target] = source_pair
+        
+        targets = target_to_source.keys()
+        result: Dict[str, Tuple[str, List[str]]] = {}
+        
+        for target in targets:
+            gateways_path: List[str] = []
+            seen_sources: Set[str] = set([target])
+            
+            source = None
+            prev_source_pair = target_to_source.get(target, None)
+
+            while prev_source_pair is not None:
+                source, gateway = prev_source_pair
+                if source in seen_sources:
+                    # loop detected: stop resolution and do not store any route
+                    source = None
+                    break
+                else:
+                    seen_sources.add(source)
+                    gateways_path.append(gateway)
+                    prev_source_pair = target_to_source.get(source, None)
+
+            if source is not None:
+                gateways_path.reverse()
+                result[target] = (source, gateways_path)
+
+        return result
+
+
+    

--- a/src/cantools/database/can/formats/arxml/node_specifics.py
+++ b/src/cantools/database/can/formats/arxml/node_specifics.py
@@ -4,5 +4,9 @@ class AutosarNodeSpecifics:
 
     AUTOSAR calls such nodes "ECU instances"...
     """
-    def __init__(self):
-        pass
+    def __init__(self, ref: str):
+        self._ref = ref
+    
+    @property
+    def ref(self) -> str:
+        return self._ref

--- a/src/cantools/database/can/message.py
+++ b/src/cantools/database/can/message.py
@@ -87,6 +87,7 @@ class Message:
                  autosar_specifics: Optional['AutosarMessageSpecifics'] = None,
                  is_extended_frame: bool = False,
                  is_fd: bool = False,
+                 is_event_driven: bool = False,
                  bus_name: Optional["Bus.BusName"] = None,
                  signal_groups: Optional[List[SignalGroup]] = None,
                  strict: bool = True,
@@ -110,6 +111,7 @@ class Message:
         self._header_byte_order = header_byte_order
         self._is_extended_frame = is_extended_frame
         self._is_fd = is_fd
+        self._is_event_driven = is_event_driven
         self._name = name
         self._length = length
         self._unused_bit_pattern = unused_bit_pattern
@@ -298,6 +300,18 @@ class Message:
     @is_fd.setter
     def is_fd(self, value):
         self._is_fd = value
+    
+    @property
+    def is_event_driven(self):
+        """``True`` if the message is event driven ``False`` otherwise.
+
+        """
+
+        return self._is_event_driven
+
+    @is_event_driven.setter
+    def is_event_driven(self, value: bool):
+        self._is_event_driven = value
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Extend Autosar 4 parsing capability:
- Improve parsing of sender/receiver information leveraging on PORT associated to PDU-TRIGGERING
- For messages routed through a gateway, store the real message sender together with the list of gateways routing the message
- Expose connections between ECUs and CAN networks
- Best effort parsing for dynamic alternatives of multiplexed PDUs missing the selector field
- Improvements to type hinting
- Parsing delay time and whether a frame is event driven from ARXML